### PR TITLE
Fix ordering of $PROJECT and $BUCKET

### DIFF
--- a/demo
+++ b/demo
@@ -7,13 +7,13 @@ export -f input
 
 export SHARED_PROJECT=moz-fx-data-shar-nonprod-efed
 export COMPUTE_INSTANCE_NAME=instance-1
-export BUCKET=gs://$PROJECT
 export PUBSUB_SUBSCRIPTION=telemetry-decoded.demo-subscription
 export COMPUTE_SERVICE_ACCOUNT=demo-service-account
 export DATAFLOW_SERVICE_ACCOUNT=dataflow-service-account
 export DATAFLOW_PUBSUB_SUBSCRIPTION=structured-decoded.demo-sink
 export ZONE=us-west1-a
 export PROJECT="${PROJECT:-$USER-sandbox-demo}"
+export BUCKET=gs://$PROJECT
 echo "Project ID is ${PROJECT}"
 [[ $(gcloud config get-value project 2>/dev/null) == "$PROJECT" ]] || gcloud config set project $PROJECT
 


### PR DESCRIPTION
This prevents the dataflow demo from working properly. Everything else works fine once the APIs are turned on. 